### PR TITLE
fix: Scale CPU limit to NanoCPUs

### DIFF
--- a/internal/runners/docker/docker.go
+++ b/internal/runners/docker/docker.go
@@ -23,8 +23,12 @@ import (
 )
 
 const (
-	imageName   = "leil-test"
-	corePattern = "/tmp/temp-cores/core-%e-%p-%t"
+	imageName      = "leil-test"
+	corePattern    = "/tmp/temp-cores/core-%e-%p-%t"
+	nanoCPUsPerCPU = 1_000_000_000
+	// maxCPUCount is the largest CPU count that fits in int64 once scaled to
+	// nanoCPUs, used to guard against overflow on absurd --cpus values.
+	maxCPUCount = (1<<63 - 1) / nanoCPUsPerCPU
 )
 
 type DockerRunner struct {
@@ -173,7 +177,7 @@ func getDefaultHostConfig(options utils.TestOptions) container.HostConfig {
 					Hard: -1,
 				},
 			},
-			NanoCPUs: int64(options.CpuLimit),
+			NanoCPUs: max(0, min(int64(options.CpuLimit), maxCPUCount)) * nanoCPUsPerCPU,
 		},
 		Tmpfs: map[string]string{
 			"/mnt/ramdisk": "rw,mode=1777,size=2g",

--- a/internal/runners/docker/docker_test.go
+++ b/internal/runners/docker/docker_test.go
@@ -1,0 +1,50 @@
+package docker
+
+import (
+	"testing"
+
+	"leil.io/leil-tests/internal/utils"
+)
+
+func TestGetDefaultHostConfigSetsNanoCPUsInDockerUnits(t *testing.T) {
+	for _, testCase := range []struct {
+		name        string
+		cpuLimit    int
+		wantNanoCPU int64
+	}{
+		{
+			name:        "zero CPUs (unlimited)",
+			cpuLimit:    0,
+			wantNanoCPU: 0,
+		},
+		{
+			name:        "negative CPUs (clamped to 0)",
+			cpuLimit:    -1,
+			wantNanoCPU: 0,
+		},
+		{
+			name:        "one CPU",
+			cpuLimit:    1,
+			wantNanoCPU: nanoCPUsPerCPU,
+		},
+		{
+			name:        "four CPUs",
+			cpuLimit:    4,
+			wantNanoCPU: 4 * nanoCPUsPerCPU,
+		},
+		{
+			name:        "above max (clamped to avoid int64 overflow)",
+			cpuLimit:    maxCPUCount + 1,
+			wantNanoCPU: maxCPUCount * nanoCPUsPerCPU,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			config := getDefaultHostConfig(utils.TestOptions{CpuLimit: testCase.cpuLimit})
+
+			if config.Resources.NanoCPUs != testCase.wantNanoCPU {
+				t.Fatalf("NanoCPUs = %d, want %d", config.Resources.NanoCPUs,
+					testCase.wantNanoCPU)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Docker expects NanoCPUs values in units of 10^-9 CPUs. Scale the integer cpus option before setting HostConfig so cpus=1 maps to one CPU worth of quota instead of one nanocpu.

Add a unit test for the host config conversion.