### PR TITLE
feat: show test execution time in result output

### DIFF
--- a/internal/reports/report.go
+++ b/internal/reports/report.go
@@ -59,12 +59,13 @@ func (testReport *TestReport) OKResults(printAll bool) string {
 	for i, test := range testReport.Runs {
 		if test.Result == TestSuccess {
 			if len(testReport.Runs) == 1 {
-				strOutput += fmt.Sprintf("TEST %s: OK\n", test.TestName)
+				strOutput += fmt.Sprintf("TEST %s: OK (%s)\n", test.TestName, test.Time.Round(time.Millisecond))
 			} else {
-				strOutput += fmt.Sprintf("TEST %s (%v/%v): OK (FLAKY)\n",
+				strOutput += fmt.Sprintf("TEST %s (%v/%v): OK (FLAKY) (%s)\n",
 					test.TestName,
 					i+1,
 					len(testReport.Runs),
+					test.Time.Round(time.Millisecond),
 				)
 			}
 			if printAll {
@@ -85,12 +86,13 @@ func (testReport *TestReport) FailedResults(printAll bool) (string, bool) {
 	for i, test := range testReport.Runs {
 		if test.Result == TestFailed {
 			if len(testReport.Runs) == 1 {
-				strOutput += fmt.Sprintf("TEST %s: FAILED\n", test.TestName)
+				strOutput += fmt.Sprintf("TEST %s: FAILED (%s)\n", test.TestName, test.Time.Round(time.Millisecond))
 			} else {
-				strOutput += fmt.Sprintf("TEST %s (%v/%v): FAILED\n",
+				strOutput += fmt.Sprintf("TEST %s (%v/%v): FAILED (%s)\n",
 					test.TestName,
 					i+1,
 					len(testReport.Runs),
+					test.Time.Round(time.Millisecond),
 				)
 			}
 			if printAll {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
@@ -189,14 +190,14 @@ func testWorker(jobs <-chan *Test, wg *sync.WaitGroup, options utils.TestOptions
 					continue
 				}
 			} else {
-				log.Printf("Test %s finished: FAILED", job.Name)
+				log.Printf("Test %s finished: FAILED (%s)", job.Name, report.Time.Round(time.Millisecond))
 			}
 			if options.SkipTestsOnFail {
 				log.SetOutput(io.Discard)
 				job.CancelRun()
 			}
 		} else if report.Result == reports.TestSuccess {
-			log.Printf("Test %s finished: OK", job.Name)
+			log.Printf("Test %s finished: OK (%s)", job.Name, report.Time.Round(time.Millisecond))
 		}
 	}
 }


### PR DESCRIPTION
Append per-test duration (rounded to milliseconds) to OK and FAILED result lines in both the summary report and the live worker logs. Duration is read from the existing TestReport.Time field, so no new measurement logic is added.

Output-only change: CI consumes results via JUnit XML (--xml-path), which is unaffected.